### PR TITLE
Thin dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "PTJPLSM"
-version = "1.5.3"
+version = "1.5.4"
 description = "Priestley-Taylor Jet Propulsion Laboratory Soil Moisutre Evapotranspiration Model"
 readme = "README.md"
 authors = [
@@ -17,19 +17,12 @@ classifiers = [
 ]
 dependencies = [
     "check-distribution",
-    "ECOv002-calval-tables",
-    "ECOv002-CMR>=1.0.5",
-    "ECOv002-granules>=1.0.3",
-    "ECOv003-granules",
     "gedi-canopy-height",
     "GEOS5FP>=1.1.1",
-    "monte-carlo-sensitivity",
     "numpy",
     "pandas",
     "PTJPL>=1.4.3",
     "rasters>=1.7.0",
-    "scikit-learn",
-    "seaborn",
     "SEBAL-soil-heat-flux",
     "soil-capacity-wilting>=1.2.0",
     "solar-apparent-time",
@@ -45,6 +38,14 @@ dev = [
     "jupyter",
     "pytest",
     "twine"
+]
+
+[dependency-groups]
+sensitivity = [
+    "ECOv002-calval-tables",
+    "ECOv002-granules>=1.0.3",
+    "monte-carlo-sensitivity",
+    "seaborn",
 ]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
Make the library more lightweight to install, by removing dependencies which aren't used at all, and moving sensitivity-specific dependencies to a dependency group.

Closes #24 